### PR TITLE
Update wiring-pi dependency to use wiringpi-node

### DIFF
--- a/es6/lib/stepper.js
+++ b/es6/lib/stepper.js
@@ -1,5 +1,5 @@
 import _               from 'lodash';
-import wpi, { OUTPUT } from 'wiring-pi';
+import wpi, { OUTPUT } from 'wiringpi-node';
 import EventEmitter    from 'events';
 import NanoTimer       from 'nanotimer';
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "lodash": "^4.17.2",
     "nanotimer": "^0.3.14",
-    "wiring-pi": "^2.2.1"
+    "wiringpi-node": "^2.4.4"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",


### PR DESCRIPTION
Adds support for a wider range of Raspberry Pi models, thus fixing the
following error:
```
Unable to determine hardware version. I see: Hardware	: BCM2835,
 - expecting BCM2708 or BCM2709. Please report this to
projects@drogon.net
```